### PR TITLE
Scrape on interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 The scraper is in charge of requesting the different rundeck instances to get the execution history, and the UI is rendering the executions across all instances in a swimlane chart.
 
-# Building
+# Documentation / Usage :memo:
+
+Documentation is available at [https://roukien.github.io/rundeck-activity-monitor/](https://roukien.github.io/rundeck-activity-monitor/)
+
+# Contributing
+
+## Building RAM
 
 1. build the frontend app (which is basically a react SPA)
 2. build the backend app and embedd the frontend inside it
@@ -12,5 +18,6 @@ The scraper is in charge of requesting the different rundeck instances to get th
 ## Running locally
 
 1. Start the postgresql container (it is recommanded to run the one described in the `docker-compose.yml` file)
-2. Ensure the schema is up to date by running `ram database update`
+2. Ensure the schema is up to date by running `cd backend && go run ram.go database update`
 3. Start developping
+4. optionnally start the UI `cd frontend && npm run dev` (requires you to run the backend server: `go run ram.go serve`)

--- a/backend/ram.go
+++ b/backend/ram.go
@@ -4,6 +4,7 @@ import (
 	"ROUKIEN/rundeck-activity-monitor/cmd"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/urfave/cli/v2"
@@ -14,6 +15,17 @@ func main() {
 }
 
 func run(args []string) {
+	formatter := &logrus.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "2006-01-02 15:04:05",
+	}
+
+	logLevel, err := logrus.ParseLevel(os.Getenv("RAM_LOG_LEVEL"))
+	if err == nil {
+		logrus.SetLevel(logLevel)
+	}
+
+	logrus.SetFormatter(formatter)
 	app := &cli.App{
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/backend/rundeck/client.go
+++ b/backend/rundeck/client.go
@@ -97,7 +97,7 @@ func (rd *Rundeck) ListProjectExecutions(project string, so *spec.ScrapeOptions)
 			params.Add("offset", strconv.Itoa(offset))
 
 			if so.NewerThan != nil {
-				since := so.NewerThan.UTC().UnixMilli()
+				since := time.Now().Add(-*so.NewerThan).UTC().UnixMilli()
 				params.Add("begin", strconv.FormatInt(since, 10))
 			} else {
 				begin := so.Begin.UTC().UnixMilli()

--- a/backend/rundeck/spec/Execution.go
+++ b/backend/rundeck/spec/Execution.go
@@ -35,7 +35,7 @@ func NewRundeckDate(datefrom time.Time) RundeckDate {
 type ScrapeOptions struct {
 	Begin     *time.Time
 	End       *time.Time
-	NewerThan *time.Time
+	NewerThan *time.Duration
 }
 
 func NewScrapeOptions(opts map[string]string) (*ScrapeOptions, error) {
@@ -45,9 +45,9 @@ func NewScrapeOptions(opts map[string]string) (*ScrapeOptions, error) {
 		if err != nil {
 			return nil, err
 		}
-		newTime := time.Now().Add(-duration)
+
 		return &ScrapeOptions{
-			NewerThan: &newTime,
+			NewerThan: &duration,
 		}, nil
 	}
 

--- a/backend/rundeck/spec/Execution_test.go
+++ b/backend/rundeck/spec/Execution_test.go
@@ -29,11 +29,9 @@ func TestNewScrapeOptionsNewerThan(t *testing.T) {
 		"newer-than": "24h",
 	}
 
-	expectedDate := time.Now().Add(-24 * time.Hour)
-
 	so, err := NewScrapeOptions(opts)
 	assert.Nil(t, err)
 	assert.Nil(t, so.Begin)
 	assert.Nil(t, so.End)
-	assert.Equal(t, expectedDate.UTC().Hour(), so.NewerThan.UTC().Hour())
+	assert.Equal(t, time.Duration(24*time.Hour), *so.NewerThan)
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,10 @@ The Webserver aims to visualize rundeck executions and offer an intuitive UI to 
 
 You can start a scraping process of all your rundeck instances with the following command. It will scrape in parallel every projects of every rundeck instance that you configured.
 
+> You can either scrape your instances with a one-shot process (that will exit once the scraping is over) or as a daemon process, which scrapes the instances on a regular interval
+
+As an example
+
 ```shell
 export RAM_DB_DSN=postgres://...
 ram scrape --newer-than=24h
@@ -78,6 +82,13 @@ You can also decide to scrape every executions that ended in a given timeframe w
 ```shell
 export RAM_DB_DSN=postgres://...
 ram scrape --begin="2022-04-21T00:00:00.000Z" --end="2022-04-24T00:00:00.000Z"
+```
+
+If you want to scrape your instances every five minutes, you can use the `interval` option
+
+```shell
+export RAM_DB_DSN=postgres://...
+ram scrape --newer-than=5m --interval=5m
 ```
 
 ### Serving

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,3 +109,8 @@ By default, the webserver will start on port 4000.
 RAM will query the executions that _ended_ in the given timeframe. That means that if you run the `scrape` command every minutes, you only need to scrape for the last past 5minutes (with the `--newer-than=5m` option). Scraping will be way quicker and will have a smaller footprint on your rundeck server.
 
 If you need to scrape jobs in a given timeframe (because something went wrong during a scrape), you can decide to scrape that timeframe by using the `begin` & `end` options.
+
+
+### Managing RAM log verbosity
+
+Start your processes with the `RAM_LOG_LEVEL` environment variable so something that [sirupsen/logrus](https://github.com/sirupsen/logrus) will understand (trace/debug/warning...)


### PR DESCRIPTION
Fixes #14 

This PR adds an `interval` option on the scrape command to let the user scrape periodically, avoiding the need to configure stuff like cronjobs.